### PR TITLE
start_time and end_time to second

### DIFF
--- a/docs/cloudwatch_logs_insights.md
+++ b/docs/cloudwatch_logs_insights.md
@@ -9,7 +9,7 @@ query_runner "cloudwatch_logs_insights" "default" {
 
 query "cw_logs" {
   runner = query_runner.cloudwatch_logs_insights.default
-  start_time = strftime_in_zone("%Y-%m-%dT%H:%M:%S%z", "UTC", now() - duration("15m"))
+  start_time = now() - duration("15m")
   query  = <<EOT
 fields @timestamp, @message
 | sort @timestamp desc

--- a/lambda/config.hcl
+++ b/lambda/config.hcl
@@ -4,14 +4,14 @@ query_runner "cloudwatch_logs_insights" "default" {
 
 query "lambda_logs" {
   runner     = query_runner.cloudwatch_logs_insights.default
-  start_time = strftime_in_zone("%Y-%m-%dT%H:%M:%S%z", "UTC", now() - duration("15m"))
-  end_time   = strftime_in_zone("%Y-%m-%dT%H:%M:%S%z", "UTC", now())
+  start_time = now() - duration("15m")
+  end_time   = now()
   query      = <<EOT
 fields @timestamp, @message
     | sort @timestamp desc
     | limit 5
 EOT
   log_group_names = [
-     "/aws/lambda/${var.function_name}",
+    "/aws/lambda/${var.function_name}",
   ]
 }


### PR DESCRIPTION
```hcl
  query_runner "cloudwatch_logs_insights" "default" {
    region = "ap-northeast-1"
  }
  
  query "lambda_logs" {
    runner     = query_runner.cloudwatch_logs_insights.default
    start_time = now() - duration("15m")
    end_time   = now()
    query      = <<EOT
  fields @timestamp, @message
      | sort @timestamp desc
      | limit 5
  EOT
    log_group_names = [
      "/aws/lambda/${var.function_name}",
    ]
  }
```